### PR TITLE
docs: add bilingual mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ Abra o app e aguarde o carregamento dos catálogos.
 Use os filtros (Canal/Tipo) para refinar a lista.
 Selecione um item para Copiar URL (área de transferência) ou Baixar (do servidor da Apple).
 🧭 Fluxograma (como funciona)
+
+```mermaid
 flowchart TD
-    A[Iniciar app] --> B[Carregar catálogos oficiais<br/>swscan.apple.com]
+    A([Iniciar app]) --> B[Carregar catálogos oficiais<br/>swscan.apple.com]
     B --> C[Extrair produtos InstallAssistant]
     C --> D[Normalizar itens e remover duplicados]
     D --> E[Aplicar filtros (Canal/Tipo/Build)]
@@ -41,6 +43,36 @@ flowchart TD
     F -->|Baixar| H[Download direto do servidor Apple]
     F -->|Ver detalhes| I[Mostrar metadados: Versão/Build/Data/Catálogo/Tamanho]
     H --> J[Salvar arquivo no local escolhido]
+    classDef start fill:#b3e5fc,stroke:#333,stroke-width:1px;
+    classDef decision fill:#ffe0b2,stroke:#333,stroke-width:1px;
+    class A start;
+    class F decision;
+```
+
+*O diagrama mostra o fluxo de funcionamento do app.*  
+*The diagram shows how the app works.*
+
+🧭 Flowchart (how it works)
+
+```mermaid
+flowchart TD
+    A([Launch app]) --> B[Load official catalogs<br/>swscan.apple.com]
+    B --> C[Extract InstallAssistant products]
+    C --> D[Normalize items and remove duplicates]
+    D --> E[Apply filters (Channel/Type/Build)]
+    E --> F{User action}
+    F -->|Copy URL| G[URL copied to clipboard]
+    F -->|Download| H[Direct download from Apple's server]
+    F -->|View details| I[Show metadata: Version/Build/Date/Catalog/Size]
+    H --> J[Save file to chosen location]
+    classDef start fill:#b3e5fc,stroke:#333,stroke-width:1px;
+    classDef decision fill:#ffe0b2,stroke:#333,stroke-width:1px;
+    class A start;
+    class F decision;
+```
+
+*O diagrama mostra o fluxo de funcionamento do app.*  
+*The diagram shows how the app works.*
 ❓FAQ
 Por que aparece Tamanho “N/A”?
 Alguns catálogos não informam SizeBytes. O download continua funcional.


### PR DESCRIPTION
## Summary
- convert README flowchart into Mermaid with start/decision styling
- add bilingual caption and English diagram

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68a5350cda748328a5aaaf4f7d8a97ca

## Summary by Sourcery

Update README flowchart to styled Mermaid diagrams and include bilingual (Portuguese and English) captions and diagrams.

Documentation:
- Convert the existing ASCII flowchart in README to Mermaid syntax with custom start and decision node styling
- Add an English version of the flowchart alongside the original Portuguese diagram
- Include bilingual captions describing the diagram in both Portuguese and English