### PR TITLE
Fix Mermaid line breaks in README flowcharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ shasum -a 256 ~/Downloads/macOS-InstallAssistant-Browser.zip
 ### 🧭 Fluxograma (como funciona)
 ```mermaid
 flowchart TD
-    A[Iniciar app] --> B[Carregar catálogos oficiais<br/>swscan.apple.com]
+    A[Iniciar app] --> B["Carregar catálogos oficiais\nswscan.apple.com"]
     B --> C[Extrair produtos InstallAssistant]
     C --> D[Normalizar itens e remover duplicados]
     D --> E[Aplicar filtros (Canal/Tipo/Build)]
@@ -125,7 +125,7 @@ shasum -a 256 ~/Downloads/macOS-InstallAssistant-Browser.zip
 ### 🧭 Flowchart (how it works)
 ```mermaid
 flowchart TD
-    A[Launch app] --> B[Load official catalogs<br/>swscan.apple.com]
+    A[Launch app] --> B["Load official catalogs\nswscan.apple.com"]
     B --> C[Extract InstallAssistant products]
     C --> D[Normalize items and remove duplicates]
     D --> E[Apply filters (Channel/Type/Build)]


### PR DESCRIPTION
## Summary
- replace HTML `<br/>` with newline in Portuguese flowchart
- replace HTML `<br/>` with newline in English flowchart

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a53ac7d6d08328be89a93f961bd4d0

## Summary by Sourcery

Fix Mermaid flowchart line breaks in README by replacing HTML <br/> tags with newline escapes

Documentation:
- Replace HTML <br/> with '\n' in Portuguese README flowchart
- Replace HTML <br/> with '\n' in English README flowchart